### PR TITLE
debian: Fix libjpeg build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>= 4.0.0),
                dh-autoreconf,
                libcupsys2-dev | libcups2-dev,
                libcupsimage2-dev,
-               libjpeg8,
+               libjpeg-dev,
                libstdc++6
 Standards-Version: 3.7.2
 


### PR DESCRIPTION
2 issues here. First, we want to move off of libjpeg8 and onto
libjpeg-turbo to sync up with debian. Second, the build dependency
should be on the -dev package and not just the runtime library so that
the linker can find the libjpeg.so symlink for -ljpeg.

https://phabricator.endlessm.com/T10823
