### PR TITLE
Add github action to publish deb packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Publish release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Publish binaries
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -qq debhelper libcups2-dev
+    - uses: actions/checkout@v2
+    - name: Build
+      run: fakeroot debian/rules binary
+    - name: Upload binaries to release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ../*.deb
+        file_glob: true
+        tag: deb_packages_${{ github.ref }}
+        overwrite: true
+        body: "Release with generated deb packages"


### PR DESCRIPTION
This repository have a ready to use debian manifests, not like the official epson site, thank you for that!

I propose to generate common .deb packages as additional release for peasants like me, it will trigger on tag creation and requires zero work from maintainer's side (and github actions is 100% free to use). 

I'm open to change anything related to release format (for ex. name).

Example: 
- https://github.com/gmelikov/epson-inkjet-printer/releases 
- https://github.com/gmelikov/epson-inkjet-printer/runs/7288292138